### PR TITLE
Added min amount to receive for proposals

### DIFF
--- a/contracts/FundToken.sol
+++ b/contracts/FundToken.sol
@@ -154,8 +154,9 @@ contract FundToken is ERC20, Ownable
     /// @param _assetToTrade The address of the asset to trade (e.g., USDC)
     /// @param _assetToGet The address of the asset to get (e.g., WETH)
     /// @param _amountIn The amount of the asset to trade
+    /// @param _minAmountToReceive The minimum amount of the asset to get to receive (slippage protection)
     /// @return amountOut The amount of the asset received from the swap
-    function swapAsset(address _assetToTrade, address _assetToGet, uint256 _amountIn) external onlyOwner
+    function swapAsset(address _assetToTrade, address _assetToGet, uint256 _amountIn, uint256 _minAmountToReceive) external onlyOwner
         returns (uint256 amountOut)
     {
         TransferHelper.safeApprove(_assetToTrade, address(s_swapRouter), _amountIn); 
@@ -168,7 +169,7 @@ contract FundToken is ERC20, Ownable
                 recipient: address(this),
                 // deadline: block.timestamp,
                 amountIn: _amountIn,
-                amountOutMinimum: 0,
+                amountOutMinimum: _minAmountToReceive,
                 sqrtPriceLimitX96: 0
             });
         amountOut = s_swapRouter.exactInputSingle(params);

--- a/contracts/interfaces/IFundToken.sol
+++ b/contracts/interfaces/IFundToken.sol
@@ -18,5 +18,6 @@ interface IFundToken is IERC20Extended
     function getAssets() external view returns (Asset[] memory);
 
     function swapAsset(address _assetToTrade,
-        address _assetToGet, uint256 _amountIn) external returns (uint256);
+        address _assetToGet, uint256 _amountIn,
+        uint256 _minAmountToReceive) external returns (uint256);
 }

--- a/scripts/prepopulatedFund.ts
+++ b/scripts/prepopulatedFund.ts
@@ -47,10 +47,10 @@ async function main() {
     await fundController.addAssetToFund(await cbBTC.getAddress(), baseMainnetConstants.cbBTCAggregatorAddress);
 
     const amountToSpendProposal1_usdc = 50_000n;
-    await fundController.connect(addr1).createProposal([await usdc.getAddress()], [await wETH.getAddress()], [amountToSpendProposal1_usdc * 10n ** await usdc.decimals()]);
+    await fundController.connect(addr1).createProposal([await usdc.getAddress()], [await wETH.getAddress()], [amountToSpendProposal1_usdc * 10n ** await usdc.decimals()], [0]);
 
     const amountToSpendProposal2_usdc = 100_000n;
-    await fundController.connect(addr1).createProposal([await usdc.getAddress()], [await cbBTC.getAddress()], [amountToSpendProposal2_usdc * 10n ** await usdc.decimals()]);
+    await fundController.connect(addr1).createProposal([await usdc.getAddress()], [await cbBTC.getAddress()], [amountToSpendProposal2_usdc * 10n ** await usdc.decimals()], [0]);
 
     await fundController.connect(owner).intentToAccept(1n);
     await fundController.connect(owner).intentToAccept(2n);


### PR DESCRIPTION
- Added a minimum amount to receive back from a proposal trade
    - This parameter is passed directly to uniswap

TODO: Added a minimum amount to receive when doing uniswap trades for distribution when buying in and also for selling out all of the user's assets to USDC